### PR TITLE
fix: WS not being path aware

### DIFF
--- a/channels/webui/static/js/init.js
+++ b/channels/webui/static/js/init.js
@@ -104,8 +104,11 @@ async function init() {
         function connectWebSocket() {
             // Determine protocol (ws:// or wss://)
             const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-            const wsUrl = `${wsProtocol}//${window.location.host}/ws`;
-
+            const pathname = `${window.location.pathname || '/'}`;
+            const pathBase = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+            const wsPath = `${pathBase === '' ? '' : pathBase}/ws`;
+            const wsUrl = `${wsProtocol}//${window.location.host}${wsPath}`;
+            
             socket = new WebSocket(wsUrl);
             window.socket = socket; // Make socket globally accessible for send.js etc.
 


### PR DESCRIPTION
Fix for websocket not being path aware (if it is not hosted directly on a port)