### PR TITLE
fix: normalize storage keys for cross-platform compatibility

### DIFF
--- a/core/storage.py
+++ b/core/storage.py
@@ -252,7 +252,7 @@ class StorageDict(dict):
                     for filename in files:
                         if filename.endswith(".md"):
                             rel_path = os.path.relpath(os.path.join(root, filename), self.path)
-                            key = rel_path[:-3]  # remove .md extension
+                            key = rel_path.replace(os.sep, "/")[:-3]  # normalize separators, remove .md extension
                             if key not in flat_items:
                                 os.remove(os.path.join(root, filename))
 

--- a/core/storage.py
+++ b/core/storage.py
@@ -291,7 +291,7 @@ class StorageDict(dict):
                         if filename.endswith(".md"):
                             full_path = os.path.join(root, filename)
                             rel_path = os.path.relpath(full_path, self.path)
-                            key = rel_path[:-3]  # remove .md extension
+                            key = rel_path.replace(os.sep, "/")[:-3]  # normalize separators, remove .md extension
 
                             with open(full_path, "r", encoding="utf-8") as f:
                                 flat_dict[key] = str(f.read())


### PR DESCRIPTION
Paths from os.path.relpath use `\` on Windows but all the code expects `/`, causing docs and notes modules to fail. This normalizes the keys to forward slashes across all platforms when they're created.