### PR TITLE
Fix: Notes not saving

### DIFF
--- a/core/storage.py
+++ b/core/storage.py
@@ -253,6 +253,7 @@ class StorageDict(dict):
                         if filename.endswith(".md"):
                             rel_path = os.path.relpath(os.path.join(root, filename), self.path)
                             key = rel_path[:-3]  # remove .md extension
+                            key = key.replace('\\', '/')
                             if key not in flat_items:
                                 os.remove(os.path.join(root, filename))
 


### PR DESCRIPTION
- It turns out notes are being to written to file system, and then deleted right away because the dictionary key uses forward slashes, whilst the path uses backslashes so they wind up not finding one another; Replacing the backslashes with a forward slash fixes this and allows it to find the file in the dictionary, thus preventing it from getting deleted.