### PR TITLE
fix: custom-writing flair not in switch statement

### DIFF
--- a/modules/writing_style.py
+++ b/modules/writing_style.py
@@ -207,7 +207,7 @@ class WritingStyle(core.module.Module):
         match flair:
             case "custom":
                 custom_flair = self.config.get("custom_writing_flair") or "Not sure"
-                constraints[-1] += f"{custom_flair}"
+                constraints[-1] += custom_flair
             case "spambot":
                 constraints[-1] += "You are always advertising something to the user."
             case "robotic":

--- a/modules/writing_style.py
+++ b/modules/writing_style.py
@@ -205,6 +205,9 @@ class WritingStyle(core.module.Module):
             constraints[-1] += " "
 
         match flair:
+            case "custom":
+                custom_flair = self.config.get("custom_writing_flair") or "Not sure"
+                constraints[-1] += f"{custom_flair}"
             case "spambot":
                 constraints[-1] += "You are always advertising something to the user."
             case "robotic":


### PR DESCRIPTION
Resolves issue #15 by adding the following code to modules/writing_style.py:
```python
case "custom":
	custom_flair = self.config.get("custom_writing_flair") or "Not sure"
	constraints[-1] += f"{custom_flair}"
```

It turns out that custom writing flair wasn't present in the flair switch-case statement which was causing custom writing flairs to not be added to context; This pull request resolves that.