### PR TITLE
fix: add light theme code syntax highlighting (closes #23)

### DIFF
--- a/channels/webui/index.html
+++ b/channels/webui/index.html
@@ -19,7 +19,7 @@
 
     <script src="/static/js/lib/purify.min.js"></script> <!-- XSS protection -->
     <script src="/static/js/lib/marked.min.js"></script>
-    <link rel="stylesheet" href="/static/css/code-themes/github-dark.css">
+    <link rel="stylesheet" id="code-theme" href="/static/css/code-themes/github-dark.css">
     <script src="/static/js/lib/highlight.min.js"></script>
 </head>
 <body>

--- a/channels/webui/static/css/code-themes/github-light.css
+++ b/channels/webui/static/css/code-themes/github-light.css
@@ -1,0 +1,10 @@
+pre code.hljs{display:block;overflow-x:auto;padding:1em}code.hljs{padding:3px 5px}/*!
+  Theme: GitHub
+  Description: Light theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-light
+  Current colors taken from GitHub's CSS
+*/.hljs{color:#24292e;background:#fff}.hljs-doctag,.hljs-keyword,.hljs-meta .hljs-keyword,.hljs-template-tag,.hljs-template-variable,.hljs-type,.hljs-variable.language_{color:#d73a49}.hljs-title,.hljs-title.class_,.hljs-title.class_.inherited__,.hljs-title.function_{color:#6f42c1}.hljs-attr,.hljs-attribute,.hljs-literal,.hljs-meta,.hljs-number,.hljs-operator,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id,.hljs-variable{color:#005cc5}.hljs-meta .hljs-string,.hljs-regexp,.hljs-string{color:#032f62}.hljs-built_in,.hljs-symbol{color:#e36209}.hljs-code,.hljs-comment,.hljs-formula{color:#6a737d}.hljs-name,.hljs-quote,.hljs-selector-pseudo,.hljs-selector-tag{color:#22863a}.hljs-subst{color:#24292e}.hljs-section{color:#005cc5;font-weight:700}.hljs-bullet{color:#735c0f}.hljs-emphasis{color:#24292e;font-style:italic}.hljs-strong{color:#24292e;font-weight:700}.hljs-addition{color:#22863a;background-color:#f0fff4}.hljs-deletion{color:#b31d28;background-color:#ffeef0}

--- a/channels/webui/static/js/theming.js
+++ b/channels/webui/static/js/theming.js
@@ -70,6 +70,14 @@ function applyTheme(family, mode) {
         }
     }
 
+    // Switch code syntax highlighting theme based on mode
+    const codeThemeLink = document.getElementById('code-theme');
+    if (codeThemeLink) {
+        codeThemeLink.href = mode === 'dark'
+            ? '/static/css/code-themes/github-dark.css'
+            : '/static/css/code-themes/github-light.css';
+    }
+
     const finalThemeId = buildThemeId(family, currentThemeMode);
     const finalTheme = themes[finalThemeId];
 


### PR DESCRIPTION
## Fix: Code blocks unreadable on light themes (#23)

Currently `github-dark.css` is hardcoded in `index.html`, which renders
code blocks with dark-background colors even when a light theme is active.
This causes poor contrast for syntax-highlighted tokens.

### Changes
1. **Added `github-light.css`** — official highlight.js GitHub light theme
2. **Modified `theming.js`** — `applyTheme()` now dynamically switches the
   code theme stylesheet based on theme mode:
   - Dark mode → `github-dark.css`
   - Light mode → `github-light.css`
3. **Modified `index.html`** — added `id="code-theme"` to the code theme
   `<link>` so `theming.js` can find and swap it

### Testing
- Switch to any light theme → code blocks now render with light-adapted colors
- Switch back to dark theme → `github-dark.css` is restored
- No change in behavior when dark theme is active

Closes #23