### PR TITLE
fix: coder module and sandbox_path failing on windows

### DIFF
--- a/core/functions.py
+++ b/core/functions.py
@@ -175,4 +175,3 @@ def sandbox_path(base_path: str, requested_path: str) -> str:
         return real_path
     else:
         raise ValueError("Access denied: target path is outside sandbox")
-1

--- a/core/functions.py
+++ b/core/functions.py
@@ -117,16 +117,20 @@ def sandbox_path(base_path: str, requested_path: str) -> str:
     # we dont use os.path.normpath here because it resolves '..' and allows path traversal
     # so we do the cross-platform stuff manually instead....
     # using a simple string replacement :(
-    path = requested_path.replace("/", os.path.sep)
+    normalised_base_path = base_path.replace("\\", os.path.sep)
+    normalised_base_path = normalised_base_path.replace("/", os.path.sep)
+    
+    path = requested_path.replace("\\", os.path.sep)
+    path = path.replace("/", os.path.sep)
 
     # remove path separator at the beginning and end
     path = path.strip(os.path.sep)
 
     # remove the base path from it in case the AI/user inserts it
-    prefix = base_path + os.sep
+    prefix = normalised_base_path + os.sep
     if path.startswith(prefix):
         path = path[len(prefix):]
-    elif path == base_path:
+    elif path == normalised_base_path:
         path = ""
 
     decoded = validate_path_string(path)
@@ -138,15 +142,15 @@ def sandbox_path(base_path: str, requested_path: str) -> str:
         for i, part in enumerate(parts):
             if i == 0:
                 continue  # Skip root
-            test_path = os.path.join(base_path, *parts[:i])
+            test_path = os.path.join(normalised_base_path, *parts[:i])
             if os.path.islink(test_path):
                 raise ValueError("Symlinks are not allowed in the path")
 
     if not path:
-        return base_path
+        return normalised_base_path
 
     # more path traversal protection
-    path_in_base = os.path.join(base_path, os.path.normpath(decoded))
+    path_in_base = os.path.join(normalised_base_path, os.path.normpath(decoded))
     
     try:
         real_path = os.path.realpath(path_in_base)
@@ -156,16 +160,16 @@ def sandbox_path(base_path: str, requested_path: str) -> str:
     if os.path.islink(path_in_base):
         raise ValueError("Symlinks are not allowed in the requested path")
 
-    base_prefix = base_path + os.sep
+    base_prefix = normalised_base_path + os.sep
 
     if sys.platform == "win32":
         check_path = real_path.lower()
         check_prefix = base_prefix.lower()
-        check_base = base_path.lower()
+        check_base = normalised_base_path.lower()
     else:
         check_path = real_path
         check_prefix = base_prefix
-        check_base = base_path
+        check_base = normalised_base_path
 
     if check_path.startswith(check_prefix) or check_path == check_base:
         return real_path

--- a/core/functions.py
+++ b/core/functions.py
@@ -117,8 +117,8 @@ def sandbox_path(base_path: str, requested_path: str) -> str:
     # we dont use os.path.normpath here because it resolves '..' and allows path traversal
     # so we do the cross-platform stuff manually instead....
     # using a simple string replacement :(
-    normalised_base_path = base_path.replace("\\", os.path.sep)
-    normalised_base_path = normalised_base_path.replace("/", os.path.sep)
+    base_path = base_path.replace("\\", os.path.sep)
+    base_path = base_path.replace("/", os.path.sep)
     
     path = requested_path.replace("\\", os.path.sep)
     path = path.replace("/", os.path.sep)
@@ -127,10 +127,10 @@ def sandbox_path(base_path: str, requested_path: str) -> str:
     path = path.strip(os.path.sep)
 
     # remove the base path from it in case the AI/user inserts it
-    prefix = normalised_base_path + os.sep
+    prefix = base_path + os.sep
     if path.startswith(prefix):
         path = path[len(prefix):]
-    elif path == normalised_base_path:
+    elif path == base_path:
         path = ""
 
     decoded = validate_path_string(path)
@@ -142,15 +142,15 @@ def sandbox_path(base_path: str, requested_path: str) -> str:
         for i, part in enumerate(parts):
             if i == 0:
                 continue  # Skip root
-            test_path = os.path.join(normalised_base_path, *parts[:i])
+            test_path = os.path.join(base_path, *parts[:i])
             if os.path.islink(test_path):
                 raise ValueError("Symlinks are not allowed in the path")
 
     if not path:
-        return normalised_base_path
+        return base_path
 
     # more path traversal protection
-    path_in_base = os.path.join(normalised_base_path, os.path.normpath(decoded))
+    path_in_base = os.path.join(base_path, os.path.normpath(decoded))
     
     try:
         real_path = os.path.realpath(path_in_base)
@@ -160,16 +160,16 @@ def sandbox_path(base_path: str, requested_path: str) -> str:
     if os.path.islink(path_in_base):
         raise ValueError("Symlinks are not allowed in the requested path")
 
-    base_prefix = normalised_base_path + os.sep
+    base_prefix = base_path + os.sep
 
     if sys.platform == "win32":
         check_path = real_path.lower()
         check_prefix = base_prefix.lower()
-        check_base = normalised_base_path.lower()
+        check_base = base_path.lower()
     else:
         check_path = real_path
         check_prefix = base_prefix
-        check_base = normalised_base_path
+        check_base = base_path
 
     if check_path.startswith(check_prefix) or check_path == check_base:
         return real_path

--- a/modules/coder.py
+++ b/modules/coder.py
@@ -749,6 +749,8 @@ class Coder(core.module.Module):
                 # Not a valid regex, use simple substring matching (backward compatible)
                 query_lower = query.lower()
             
+            # placing rstrip string to avoid redefining it for every single line when it remains constant; Windows doesn't allow f-strings to have backlashes but is fine with them being in a predefined string
+            rstrip_string = '\n\r'
             for i, line in enumerate(lines):
                 if len(matches) >= max_matches:
                     break
@@ -764,14 +766,14 @@ class Coder(core.module.Module):
                         snippet = [f"--- Match at line {i+1} ---"]
                         for j in range(max(0, i - context_lines), min(num_lines, i + context_lines + 1)):
                             marker = "  <-- MATCH" if j == i else ""
-                            snippet.append(f"{j+1:4}: {lines[j].rstrip('\n\r')}{marker}")
+                            snippet.append(f"{j+1:4}: {lines[j].rstrip(rstrip_string)}{marker}")
                         matches.append("\n".join(snippet))
                 else:
                     if query_lower in line.lower():
                         snippet = [f"--- Match at line {i+1} ---"]
                         for j in range(max(0, i - context_lines), min(num_lines, i + context_lines + 1)):
                             marker = "  <-- MATCH" if j == i else ""
-                            snippet.append(f"{j+1:4}: {lines[j].rstrip('\n\r')}{marker}")
+                            snippet.append(f"{j+1:4}: {lines[j].rstrip(rstrip_string)}{marker}")
                         matches.append("\n".join(snippet))
             return self.result({"matches": len(matches), "file": file_path, "results": "\n\n".join(matches)}, success=True)
         except OSError as e:


### PR DESCRIPTION
Resolves #50 
- Fixes the coder module not initiating on windows by moving the rstrip('\n\r') bit out of the f-string (specifically the \n\r) as windows doesn't play nice with a variable in an f-string having a backslash string inside; This enables the coder module to actually load on windows
- Fixes coder module tools auto-failing when attempting to access files by *also* replacing the base path's slashes with the os.path.sep, which had caused the sandbox to reject anything and everything on windows