### PR TITLE
fix: Re-implement drag and drop file functionality and fix PDF parsing

### DIFF
--- a/channels/webui.py
+++ b/channels/webui.py
@@ -28,6 +28,8 @@ from starlette.websockets import WebSocketState
 
 import core
 import msgpack
+from io import BytesIO
+from PyPDF2 import PdfReader
 import yaml
 import logging
 import io
@@ -105,7 +107,7 @@ class ConnectionManager:
         self.connection_users[websocket] = user
 
         current_chat_id = await channel_instance.context.chat.get_id()
-        
+
         # Send log history to new connection
         if self.log_buffer:
             await websocket.send_json({
@@ -146,7 +148,7 @@ class ConnectionManager:
                     await connection.send_json(message)
             except Exception:
                 disconnected.append(connection)
-        
+
         # Clean up any dead connections
         for conn in disconnected:
             self.disconnect(conn)
@@ -171,7 +173,7 @@ class ConnectionManager:
         self.stream_buffer = []
 
         next_index = len(await channel_instance.context.chat.get())
-        
+
         async def stream_worker():
             try:
                 async for token_data in generator:
@@ -182,13 +184,13 @@ class ConnectionManager:
                         elif p_type == "content": sttus_str = "content"
                         elif p_type in ["tool_call_delta", "tool", "tool_calls"]: status_str = "tool_call"
                         elif p_type == "tool": status_str = "tool_exec"
-                        
+
                         payload = serialize_for_json(token_data)
                         payload["_meta"] = {"type": "delta", "status": status_str}
-                        
+
                         # Add to buffer
                         self.stream_buffer.append(payload)
-                        
+
                         # Broadcast immediately
                         await self.broadcast({
                             "type": "token",
@@ -208,7 +210,7 @@ class ConnectionManager:
                     "buffer": self.stream_buffer,
                     "index": next_index
                 })
-                
+
                 # Clear buffer
                 self.stream_buffer = []
                 self.active_chat_id = None
@@ -325,11 +327,11 @@ async def websocket_endpoint(websocket: WebSocket):
                         # Cancel current stream if any
                         if manager.active_stream_task and not manager.active_stream_task.done():
                             manager.active_stream_task.cancel()
-                        
+
                         # Switch context
                         await channel_instance.context.chat.load(new_chat_id)
                         manager.active_chat_id = new_chat_id
-                        
+
                         # Broadcast the switch to all clients
                         await manager.broadcast({
                             "type": "chat_switched",
@@ -341,11 +343,11 @@ async def websocket_endpoint(websocket: WebSocket):
                     # Cancel current stream
                     if manager.active_stream_task and not manager.active_stream_task.done():
                         manager.active_stream_task.cancel()
-                    
+
                     # Create new chat
                     new_id = await channel_instance.context.chat.new_chat()
                     manager.active_chat_id = new_id
-                    
+
                     # Broadcast the switch
                     await manager.broadcast({
                         "type": "chat_switched",
@@ -366,7 +368,7 @@ async def websocket_endpoint(websocket: WebSocket):
                         "chat_id": channel_instance.context.chat.current,
                         "buffer": []
                     })
-                
+
                 elif msg_type == "user_message":
                     # Handle user message via WebSocket
                     content = data.get("content")
@@ -446,6 +448,8 @@ def serialize_for_json(obj):
         return obj
     else:
         return str(obj)
+
+
 
 # -----------------------------------------------------------------------------
 # Security & Auth Middleware
@@ -804,7 +808,7 @@ async def start_ai_stream_task(chat_id: str, payload_body: dict):
     Starts an AI response stream for a given chat.
     Broadcasts the user's message with the correct index first, then streams the AI response.
     """
-    
+
     # 1. Calculate the true next index before broadcasting anything
     messages = await channel_instance.context.chat.get() or []
     next_index = len(messages)
@@ -813,7 +817,7 @@ async def start_ai_stream_task(chat_id: str, payload_body: dict):
     user_msg_payload = payload_body.copy()
     if isinstance(user_msg_payload, dict):
         user_msg_payload['index'] = next_index
-    
+
     await manager.broadcast({
         "type": "user_message_added",
         "message": user_msg_payload
@@ -861,7 +865,7 @@ async def stream_message(request: Request, user: str = Depends(require_auth)):
 
     data = await request.json()
     chat_id = await channel_instance.context.chat.get_id() or "default"
-    
+
     # Use the unified task starter
     stream_id = await start_ai_stream_task(chat_id, data)
 
@@ -954,11 +958,29 @@ async def upload_file(request: Request, user: str = Depends(require_auth)):
         filename = f.get('filename', '')
         content_b64 = f.get('content', '')
         is_image = f.get('is_image', False)
+        is_pdf = f.get('is_pdf', False)
 
         if is_image:
             image_url = f"data:image/jpeg;base64,{content_b64}"
             message_content.append({"type": "text", "text": f"[Image: {filename}]"})
             message_content.append({"type": "image_url", "image_url": {"url": image_url}})
+        elif is_pdf:
+            try:
+                pdf_bytes = base64.b64decode(content_b64)
+                reader = PdfReader(BytesIO(pdf_bytes))
+                pages_text = []
+                for i, page in enumerate(reader.pages):
+                    text = page.extract_text()
+                    if text:
+                        pages_text.append(f"--- Page {i + 1} ---\n{text}")
+                full_text = '\n\n'.join(pages_text)
+                if full_text:
+                    message_content.append({"type": "text", "text": f"[PDF: {filename}]\n{full_text}"})
+                else:
+                    message_content.append({"type": "text", "text": f"[PDF: {filename} (sending as image for OCR)]"})
+                    message_content.append({"type": "image_url", "image_url": {"url": f"data:application/pdf;base64,{content_b64}"}})
+            except Exception:
+                message_content.append({"type": "text", "text": f"[PDF: {filename} - failed to extract text]"})
         else:
             content = base64.b64decode(content_b64).decode('utf-8', errors='replace')
             message_content.append({"type": "text", "text": f"[File: {filename}]\n{content}"})
@@ -966,6 +988,35 @@ async def upload_file(request: Request, user: str = Depends(require_auth)):
     await channel_instance.context.chat.add({"role": "user", "content": message_content})
     total = len(await channel_instance.context.chat.get())
     return {'success': True, 'total': total, 'type': 'multi'}
+
+@app.post("/parse-pdf")
+async def parse_pdf(request: Request, user: str = Depends(require_auth)):
+    data = await request.json()
+    content_b64 = data.get('content', '')
+    filename = data.get('filename', 'document.pdf')
+
+    try:
+        pdf_bytes = base64.b64decode(content_b64)
+        reader = PdfReader(BytesIO(pdf_bytes))
+        pages_text = []
+        for i, page in enumerate(reader.pages):
+            text = page.extract_text()
+            if text:
+                pages_text.append(f"--- Page {i + 1} ---\n{text}")
+        full_text = '\n\n'.join(pages_text)
+        if full_text:
+            return {'success': True, 'text': full_text, 'pages': len(reader.pages)}
+
+        # Text extraction failed — return raw PDF for vision model OCR
+        return {
+            'success': True,
+            'text': None,
+            'pages': len(reader.pages),
+            'mode': 'pdf_image',
+            'pdf_base64': content_b64
+        }
+    except Exception as e:
+        return {'success': False, 'error': str(e)}
 
 # =============================================================================
 # Chat Management Routes
@@ -1320,7 +1371,7 @@ async def save_settings(request: Request, user: str = Depends(require_auth)):
     data = await request.json()
     form_data = data.get("settings", data)  # Support both formats
     changed_modules = data.get("changed_modules", [])
-    
+
     result = core.config.config.load(data=form_data)
     core.config.config.save()
 
@@ -1794,7 +1845,7 @@ class Webui(core.channel.Channel):
     def on_log(self, category, message):
         # Store log in buffer for history
         manager.add_log(category, message)
-        
+
         # Broadcast log messages to all connected webui clients
         # Since on_log is sync but manager.broadcast is async, we schedule it as a task
         log_message = {

--- a/channels/webui.py
+++ b/channels/webui.py
@@ -30,9 +30,10 @@ import core
 import msgpack
 from io import BytesIO
 from PyPDF2 import PdfReader
+import pymupdf
 import yaml
 import logging
-import io
+
 
 WEBUI_DIR = core.get_path("channels/webui")
 
@@ -181,7 +182,7 @@ class ConnectionManager:
                         p_type = token_data.get("type")
                         status_str = "idle"
                         if p_type == "reasoning": status_str = "thinking"
-                        elif p_type == "content": sttus_str = "content"
+                        elif p_type == "content": status_str = "content"
                         elif p_type in ["tool_call_delta", "tool", "tool_calls"]: status_str = "tool_call"
                         elif p_type == "tool": status_str = "tool_exec"
 
@@ -946,6 +947,7 @@ async def cancel_stream(request: Request, user: str = Depends(require_auth)):
         stream_cancellations.add(stream_id)
     return {'success': True}
 
+
 @app.post("/upload")
 async def upload_file(request: Request, user: str = Depends(require_auth)):
     data = await request.json()
@@ -967,20 +969,16 @@ async def upload_file(request: Request, user: str = Depends(require_auth)):
         elif is_pdf:
             try:
                 pdf_bytes = base64.b64decode(content_b64)
-                reader = PdfReader(BytesIO(pdf_bytes))
-                pages_text = []
-                for i, page in enumerate(reader.pages):
-                    text = page.extract_text()
-                    if text:
-                        pages_text.append(f"--- Page {i + 1} ---\n{text}")
-                full_text = '\n\n'.join(pages_text)
+                full_text, _ = await asyncio.to_thread(_extract_pdf_text_sync, pdf_bytes)
                 if full_text:
-                    message_content.append({"type": "text", "text": f"[PDF: {filename}]\n{full_text}"})
+                    message_content.append({"type": "text", "text": f"[File: {filename}]\n{full_text}"})
                 else:
-                    message_content.append({"type": "text", "text": f"[PDF: {filename} (sending as image for OCR)]"})
-                    message_content.append({"type": "image_url", "image_url": {"url": f"data:application/pdf;base64,{content_b64}"}})
+                    message_content.append({"type": "text", "text": f"[File: {filename} (sending as images for OCR)]"})
+                    page_images = await asyncio.to_thread(pdf_pages_to_images, pdf_bytes)
+                    for img_url in page_images:
+                        message_content.append({"type": "image_url", "image_url": {"url": img_url}})
             except Exception:
-                message_content.append({"type": "text", "text": f"[PDF: {filename} - failed to extract text]"})
+                message_content.append({"type": "text", "text": f"[File: {filename} - failed to extract text]"})
         else:
             content = base64.b64decode(content_b64).decode('utf-8', errors='replace')
             message_content.append({"type": "text", "text": f"[File: {filename}]\n{content}"})
@@ -989,34 +987,52 @@ async def upload_file(request: Request, user: str = Depends(require_auth)):
     total = len(await channel_instance.context.chat.get())
     return {'success': True, 'total': total, 'type': 'multi'}
 
+
+def _extract_pdf_text_sync(pdf_bytes):
+    reader = PdfReader(BytesIO(pdf_bytes))
+    pages_text = []
+    for i, page in enumerate(reader.pages):
+        text = page.extract_text()
+        if text:
+            pages_text.append(f"--- Page {i + 1} ---\n{text}")
+    return ('\n\n'.join(pages_text), len(reader.pages))
+
+
+def pdf_pages_to_images(pdf_bytes, dpi=150, max_images=10):
+    doc = pymupdf.open(stream=pdf_bytes, filetype="pdf")
+    try:
+        images = []
+        for i in range(min(len(doc), max_images)):
+            page = doc[i]
+            pix = page.get_pixmap(dpi=dpi)
+            img_b64 = base64.b64encode(pix.tobytes("png")).decode()
+            images.append(f"data:image/png;base64,{img_b64}")
+        return images
+    finally:
+        doc.close()
+
+
 @app.post("/parse-pdf")
 async def parse_pdf(request: Request, user: str = Depends(require_auth)):
     data = await request.json()
     content_b64 = data.get('content', '')
-    filename = data.get('filename', 'document.pdf')
 
     try:
         pdf_bytes = base64.b64decode(content_b64)
-        reader = PdfReader(BytesIO(pdf_bytes))
-        pages_text = []
-        for i, page in enumerate(reader.pages):
-            text = page.extract_text()
-            if text:
-                pages_text.append(f"--- Page {i + 1} ---\n{text}")
-        full_text = '\n\n'.join(pages_text)
+        full_text, page_count = await asyncio.to_thread(_extract_pdf_text_sync, pdf_bytes)
         if full_text:
-            return {'success': True, 'text': full_text, 'pages': len(reader.pages)}
+            return {'success': True, 'text': full_text, 'pages': page_count}
 
-        # Text extraction failed — return raw PDF for vision model OCR
+        page_images = await asyncio.to_thread(pdf_pages_to_images, pdf_bytes)
         return {
             'success': True,
             'text': None,
-            'pages': len(reader.pages),
+            'pages': page_count,
             'mode': 'pdf_image',
-            'pdf_base64': content_b64
+            'page_images': page_images
         }
     except Exception as e:
-        return {'success': False, 'error': str(e)}
+        return {'success': False, 'error': "Failed to parse PDF. An unexpected error occured"}
 
 # =============================================================================
 # Chat Management Routes

--- a/channels/webui/static/css/upload.css
+++ b/channels/webui/static/css/upload.css
@@ -93,3 +93,25 @@
     font-size: 0.85rem;
     color: var(--text-secondary);
 }
+
+/* PDF Preview Styles */
+.uploaded-pdf-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    max-width: 200px;
+    padding: 20px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+}
+
+.uploaded-pdf-icon {
+    font-size: 3rem;
+    line-height: 1;
+}
+
+.queue-file-icon.pdf {
+    color: var(--error);
+}

--- a/channels/webui/static/js/upload.js
+++ b/channels/webui/static/js/upload.js
@@ -250,8 +250,8 @@ async function handleFileUpload(event) {
                 previewWrapper.appendChild(previewMsg);
                 previewWrappers.push(previewWrapper);
 
-                let pdfText = "[PDF could not be parsed]";
-                let pdfFallback = null;
+                let pdfText = null;
+                let pdfPageImages = null;
                 try {
                     const parseResp = await fetch('/parse-pdf', {
                         method: 'POST',
@@ -260,26 +260,29 @@ async function handleFileUpload(event) {
                     });
                     const parseData = await parseResp.json();
                     if (parseData.success) {
-                        if (parseData.mode === 'pdf_image' && parseData.pdf_base64) {
-                            pdfFallback = parseData.pdf_base64;
-                            pdfText = `[PDF: ${file.name} (${parseData.pages} pages, sent as image for OCR)]`;
+                        if (parseData.mode === 'pdf_image' && parseData.page_images) {
+                            pdfPageImages = parseData.page_images;
+                            pdfText = `[File: ${file.name} (${parseData.pages} pages, sent as images for OCR)]`;
                         } else if (parseData.text) {
                             pdfText = parseData.text;
+                        } else {
+                            pdfText = "[PDF could not be parsed — no extractable text or images]";
                         }
                     }
                 } catch (e) {
                     console.error('Failed to parse PDF:', e);
+                    pdfText = "[PDF could not be parsed]";
                 }
 
-                if (pdfFallback) {
+                if (pdfPageImages) {
                     contentPart = [
                         { type: "text", text: pdfText },
-                        { type: "image_url", image_url: { url: `data:application/pdf;base64,${pdfFallback}` } }
+                        ...pdfPageImages.map(url => ({ type: "image_url", image_url: { url } }))
                     ];
                 } else {
                     contentPart = {
                         type: "text",
-                        text: `[PDF: ${file.name} (${pdfText.length} chars extracted)]\n${pdfText}`
+                        text: `[File: ${file.name} (${pdfText.length} chars extracted)]\n${pdfText}`
                     };
                 }
                 fileMeta = { is_pdf: true };

--- a/channels/webui/static/js/upload.js
+++ b/channels/webui/static/js/upload.js
@@ -2,74 +2,76 @@
 // Drag and Drop
 // =============================================================================
 
-// temporarily disabled
+const SUPPORTED_FILE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'application/pdf'];
 
-// ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
-//     chat.addEventListener(eventName, preventDefaults, false);
-// });
-//
-// function preventDefaults(e) {
-//     e.preventDefault();
-//     e.stopPropagation();
-// }
-//
-// ['dragenter', 'dragover'].forEach(eventName => {
-//     chat.addEventListener(eventName, () => {
-//         chat.classList.add('drag-over');
-//         dropOverlay.classList.add('active');
-//     }, false);
-// });
-//
-// ['dragleave', 'drop'].forEach(eventName => {
-//     chat.addEventListener(eventName, () => {
-//         chat.classList.remove('drag-over');
-//         dropOverlay.classList.remove('active');
-//     }, false);
-// });
-//
-// chat.addEventListener('drop', (e) => {
-//     const files = e.dataTransfer.files;
-//     if (files.length > 0) {
-//         handleFileUpload({ target: { files: files } });
-//     }
-// }, false);
-//
-// document.body.addEventListener('dragover', (e) => {
-//     // Prevent file upload overlay when dragging a chat item
-//     if (window.isDraggingChat) {
-//         e.preventDefault();
-//         return;
-//     }
-//     e.preventDefault();
-//     dropOverlay.classList.add('active');
-// });
-//
-// document.body.addEventListener('dragleave', (e) => {
-//     if (e.target === document.body || !e.relatedTarget) {
-//         dropOverlay.classList.remove('active');
-//     }
-// });
-//
-// document.body.addEventListener('drop', (e) => {
-//     // Prevent file upload when dropping a chat item
-//     if (window.isDraggingChat) {
-//         e.preventDefault();
-//         return;
-//     }
-//     e.preventDefault();
-//     dropOverlay.classList.remove('active');
-//
-//     const files = e.dataTransfer.files;
-//     if (files.length > 0) {
-//         handleFileUpload({ target: { files: files } });
-//     }
-// });
+['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+    chat.addEventListener(eventName, (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+    }, false);
+});
+
+['dragenter', 'dragover'].forEach(eventName => {
+    chat.addEventListener(eventName, (e) => {
+        e.preventDefault();
+        if (!window.isDraggingChat) {
+            chat.classList.add('drag-over');
+            dropOverlay.classList.add('active');
+        }
+    }, false);
+});
+
+['dragleave', 'drop'].forEach(eventName => {
+    chat.addEventListener(eventName, (e) => {
+        e.preventDefault();
+        chat.classList.remove('drag-over');
+        dropOverlay.classList.remove('active');
+    }, false);
+});
+
+chat.addEventListener('drop', (e) => {
+    e.preventDefault();
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+        handleFileUpload({ target: { files: files } });
+    }
+}, false);
+
+document.body.addEventListener('dragover', (e) => {
+    if (window.isDraggingChat) {
+        e.preventDefault();
+        return;
+    }
+    e.preventDefault();
+    dropOverlay.classList.add('active');
+});
+
+document.body.addEventListener('dragleave', (e) => {
+    if (e.target === document.body || !e.relatedTarget) {
+        dropOverlay.classList.remove('active');
+    }
+});
+
+document.body.addEventListener('drop', (e) => {
+    if (window.isDraggingChat) {
+        e.preventDefault();
+        return;
+    }
+    e.preventDefault();
+    dropOverlay.classList.remove('active');
+
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+        handleFileUpload({ target: { files: files } });
+    }
+});
 
 // =============================================================================
 // File Upload (Modified for Queuing)
 // =============================================================================
 const SUPPORTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 const MAX_IMAGE_SIZE = 20 * 1024 * 1024; // 20MB
+const MAX_PDF_SIZE = 25 * 1024 * 1024; // 25MB
 
 // Global queue to hold files and their UI wrappers until 'send' is clicked
 window.upload_queue = {
@@ -99,8 +101,10 @@ window.updateUploadQueueUI = function() {
     window.upload_queue.files.forEach((fileObj, index) => {
         const item = document.createElement('div');
         item.className = 'upload-queue-item';
+        const iconClass = fileObj.is_pdf ? 'queue-file-icon pdf' : (fileObj.is_image ? 'queue-file-icon image' : 'queue-file-icon');
+        const iconChar = fileObj.is_pdf ? '\uD83D\uDCC4' : '\uD83D\uDDBC\uFE0F';
         item.innerHTML = `
-        <span class="queue-file-icon">📄</span>
+        <span class="${iconClass}">${iconChar}</span>
         <span class="queue-file-name">${escapeHtml(fileObj.name)}</span>
         <button class="delete-queue-item" aria-label="Remove file">&times;</button>
         `;
@@ -147,6 +151,17 @@ async function handleFileUpload(event) {
 
         for (const file of rawFiles) {
             const isImage = SUPPORTED_IMAGE_TYPES.includes(file.type);
+            const isPdf = file.type === 'application/pdf';
+
+            if (!isImage && !isPdf && !file.type.startsWith('text/')) {
+                continue;
+            }
+
+            if (isPdf && file.size > MAX_PDF_SIZE) {
+                console.warn(`PDF ${file.name} exceeds ${MAX_PDF_SIZE / 1024 / 1024}MB limit`);
+                continue;
+            }
+
             const previewWrapper = document.createElement('div');
             previewWrapper.className = 'message-wrapper user animate-in';
             previewWrapper.dataset.index = 'pending';
@@ -155,6 +170,7 @@ async function handleFileUpload(event) {
             previewMsg.className = 'message user';
 
             let contentPart = {};
+            let fileMeta = {};
 
             if (isImage) {
                 // Image processing
@@ -192,7 +208,11 @@ async function handleFileUpload(event) {
                 img.style.width = `${width}px`;
                 img.style.height = `${height}px`;
 
-                // Prepare the parts for the final payload
+                imgContainer.appendChild(img);
+                previewMsg.appendChild(imgContainer);
+                previewWrapper.appendChild(previewMsg);
+                previewWrappers.push(previewWrapper);
+
                 contentPart = [
                     {
                         type: "text",
@@ -203,6 +223,66 @@ async function handleFileUpload(event) {
                         image_url: { url: imageDataUrl }
                     }
                 ];
+                fileMeta = { is_image: true };
+            } else if (isPdf) {
+                // PDF processing — extract text via backend
+                const pdfBase64 = await new Promise((res, rej) => {
+                    const r = new FileReader();
+                    r.onload = () => {
+                        const parts = r.result.split(',');
+                        res(parts[1] || r.result);
+                    };
+                    r.onerror = () => rej(new Error('Failed to read PDF file'));
+                    r.readAsDataURL(file);
+                });
+
+                const pdfContainer = document.createElement('div');
+                pdfContainer.className = 'uploaded-pdf-container';
+                const pdfIcon = document.createElement('div');
+                pdfIcon.className = 'uploaded-pdf-icon';
+                pdfIcon.innerHTML = '&#128196;';
+                const pdfName = document.createElement('div');
+                pdfName.className = 'uploaded-image-caption';
+                pdfName.textContent = file.name;
+                pdfContainer.appendChild(pdfIcon);
+                pdfContainer.appendChild(pdfName);
+                previewMsg.appendChild(pdfContainer);
+                previewWrapper.appendChild(previewMsg);
+                previewWrappers.push(previewWrapper);
+
+                let pdfText = "[PDF could not be parsed]";
+                let pdfFallback = null;
+                try {
+                    const parseResp = await fetch('/parse-pdf', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ content: pdfBase64, filename: file.name })
+                    });
+                    const parseData = await parseResp.json();
+                    if (parseData.success) {
+                        if (parseData.mode === 'pdf_image' && parseData.pdf_base64) {
+                            pdfFallback = parseData.pdf_base64;
+                            pdfText = `[PDF: ${file.name} (${parseData.pages} pages, sent as image for OCR)]`;
+                        } else if (parseData.text) {
+                            pdfText = parseData.text;
+                        }
+                    }
+                } catch (e) {
+                    console.error('Failed to parse PDF:', e);
+                }
+
+                if (pdfFallback) {
+                    contentPart = [
+                        { type: "text", text: pdfText },
+                        { type: "image_url", image_url: { url: `data:application/pdf;base64,${pdfFallback}` } }
+                    ];
+                } else {
+                    contentPart = {
+                        type: "text",
+                        text: `[PDF: ${file.name} (${pdfText.length} chars extracted)]\n${pdfText}`
+                    };
+                }
+                fileMeta = { is_pdf: true };
             } else {
                 // Text file processing
                 const content = await new Promise((resolve) => {
@@ -216,11 +296,14 @@ async function handleFileUpload(event) {
                     type: "text",
                     text: `[File: ${file.name}]\n${content}`
                 };
+                fileMeta = {};
             }
 
             window.upload_queue.files.push({
                 content: contentPart,
-                name: file.name
+                name: file.name,
+                is_image: fileMeta.is_image || false,
+                is_pdf: fileMeta.is_pdf || false
             });
             window.upload_queue.wrappers.push(previewWrapper);
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ json-repair
 python-ulid
 requests
 httpx
+PyPDF2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-ulid
 requests
 httpx
 PyPDF2
+PyMuPDF


### PR DESCRIPTION
Uncommented the drag-and-drop file upload that was disabled and fixed PDF parsing.

PDF parsing is currently not working as it sends the binary file data to the LLM which it cannot parse. This causes the LLM to return nothing or garbled data.

**Changes:**
1. Added a /parse-pdf endpoint and updated /upload-file to handle PDFs. Uses PyPDF2 to extract text. If extraction fails it converts the PDF into an image sends it as an image file for multi-modal models.
2. Re-implemted drag-and-drop in upload.js
3. Added new requirements (PyPDF2, and PyMuPDF) for PDF text extraction and image conversion

**AI Usage disclaimer**: Used AI to write the CSS and check the JavaScript in channels/webui/static/js/upload.js
