### PR TITLE
[core] fix deleting the only chat

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -139,7 +139,7 @@ class Chat:
         self.data.save()
 
         # Adjust current index if needed
-        if self.current:
+        if self.current is not None:
             if self.current == index:
                 # Deleted the current chat - reset or move to previous
                 self._set_current(min(index, len(self.data) - 1) if self.data else None)


### PR DESCRIPTION
I noticed that when deleting the only chat left in the WebUI, then  writing a new message or refreshing the page, there is a crash.

```
  File "C:\Users\user\openlumara\channels\webui.py", line 284, in websocket_endpoint
    await manager.connect(websocket, user)
  File "C:\Users\user\openlumara\channels\webui.py", line 107, in connect
    current_chat_id = await channel_instance.context.chat.get_id()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\openlumara\core\chat.py", line 268, in get_id
    return self.data[self.current].get("id", None)
           ~~~~~~~~~^^^^^^^^^^^^^^
IndexError: list index out of range
```

## Change
Changed the following in the delete function
```
if self.current:
```
to
```
if self.current is not None:
```
So that the branch is entered when self.current == 0



## Testing
1. Open webui from newly cloned project (to not have to delete important chats)
2. Delete the default "New Chat"
3. Refresh page or send new message
4. Confirm that with new version, there is no longer a backend error.