### PR TITLE
No destructive message history navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dev_run.sh
 *.swp
 *.swo
 *.kate-swp
+.module_cache.json
+.tiktoken_cache/

--- a/channels/webui/index.html
+++ b/channels/webui/index.html
@@ -339,6 +339,14 @@
                                 <span class="shortcut-desc">Stop generation</span>
                                 <div class="shortcut-keys"><span class="shortcut-key">Escape</span></div>
                             </div>
+                            <div class="shortcut-item">
+                                <span class="shortcut-desc">Previous user message (in input field)</span>
+                                <div class="shortcut-keys"><span class="shortcut-key">Ctrl</span><span class="shortcut-key">Up arrow</span></div>
+                            </div>
+                            <div class="shortcut-item">
+                                <span class="shortcut-desc">Next user message (in input field)</span>
+                                <div class="shortcut-keys"><span class="shortcut-key">Ctrl</span><span class="shortcut-key">Down arrow</span></div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/channels/webui/static/js/input.js
+++ b/channels/webui/static/js/input.js
@@ -5,6 +5,7 @@ const HISTORY_KEY = 'message_history';
 const MAX_HISTORY = 100;
 let messageHistory = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]');
 let historyIndex = -1;
+let currentValue = '';
 
 function saveHistory() {
     localStorage.setItem(HISTORY_KEY, JSON.stringify(messageHistory));
@@ -148,6 +149,9 @@ document.addEventListener('keydown', (event) => {
         }
 
         if (!isMobile && event.ctrlKey && (event.key === 'ArrowUp' || event.key === 'ArrowDown')) {
+            if (!currentValue.length && historyIndex === -1) {
+                currentValue = inputField.value;
+            }
             if (messageHistory.length > 0) {
                 if (event.key === 'ArrowUp') {
                     if (historyIndex === -1) {
@@ -166,7 +170,8 @@ document.addEventListener('keydown', (event) => {
                 }
 
                 if (historyIndex === -1) {
-                    inputField.value = '';
+                    inputField.value = currentValue;
+                    currentValue = '';
                 } else {
                     inputField.value = messageHistory[historyIndex];
                 }


### PR DESCRIPTION
I have many times written multiple paragraphs in the input field, then when using the arrow keys, along with Ctrl to navigate the text, had everything I've written erased by `Ctrl+UpArrow`. Today, it happened *twice*, in rapid succession, and I figured that it couldn't be much work to just fix that.

This PR stores the current value of the input field *when navigating the user message history*, using Ctrl+Up/Down Arrow, and sets the input field to the previous value when the history index is `-1`, i.e. the current message.

Also added these two keyboard shortcuts to the keyboard shortcut information modal, as they were missing.

As I was committing, I noticed that a cache file and a cache folder was 'red' in my repository, so I added these to `.gitignore`, in order to avoid accidentally commiting them.