### PR TITLE
[models] fold model load/unload into base models module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dev_run.sh
 graphify-out/
 camofox_module_fix_report.md
 fix_plan.md
+model_merge_plan.md

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dev_run.sh
 .module_cache.json
 .tiktoken_cache/
 .requirements_hash
+graphify-out/
+camofox_module_fix_report.md
+fix_plan.md

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,3 @@ dev_run.sh
 .module_cache.json
 .tiktoken_cache/
 .requirements_hash
-graphify-out/
-camofox_module_fix_report.md
-fix_plan.md
-model_merge_plan.md

--- a/channels/webui.py
+++ b/channels/webui.py
@@ -597,12 +597,30 @@ async def create_fastapi(channel):
 
         changed_modules = list(data.get("changed_modules", []))
         data.pop("changed_modules")
-        
+
+        prev_model = core.config.config.get("model", "name")
+
         result = core.config.config.load(data=data)
         core.config.config.save()
 
         if not result:
             return api_result(success=False)
+
+        # If the AI model selection changed and the models module manages load/unload,
+        # apply it to VRAM (unload current, then load the newly configured model).
+        new_model = core.config.config.get("model", "name")
+        if new_model and new_model != prev_model:
+            models_module = channel.manager.modules.get("models")
+            if (
+                models_module is not None
+                and getattr(models_module, "apply_config_model", None)
+                and models_module.config.get("enable_model_load_unload")
+            ):
+                await models_module.apply_config_model()
+                channel.log(
+                    self.name,
+                    f"Model changed to '{new_model}': unloading previous model and loading {new_model}",
+                )
 
         # Reload modules that had their settings changed
         if changed_modules:

--- a/channels/webui.py
+++ b/channels/webui.py
@@ -606,8 +606,8 @@ async def create_fastapi(channel):
         if not result:
             return api_result(success=False)
 
-        # If the AI model selection changed and the models module manages load/unload,
-        # apply it to VRAM (unload current, then load the newly configured model).
+        # if the selected model changed and the models module does load/unload,
+        # make the new model the active one in VRAM too
         new_model = core.config.config.get("model", "name")
         if new_model and new_model != prev_model:
             models_module = channel.manager.modules.get("models")
@@ -616,11 +616,8 @@ async def create_fastapi(channel):
                 and getattr(models_module, "apply_config_model", None)
                 and models_module.config.get("enable_model_load_unload")
             ):
-                await models_module.apply_config_model()
-                channel.log(
-                    self.name,
-                    f"Model changed to '{new_model}': unloading previous model and loading {new_model}",
-                )
+                await models_module.apply_config_model(prev_model)
+                channel.log(self.name, f"Applied model change to '{new_model}'")
 
         # Reload modules that had their settings changed
         if changed_modules:

--- a/core/api.py
+++ b/core/api.py
@@ -740,89 +740,53 @@ class APIClient():
 
         return model_list
 
-    def _router_base_url(self):
-        """Derive llama.cpp router base URL from api.url config (strip the /v1 suffix)."""
-        url = core.config.get("api", "url", default="")
-        return url.rstrip("/").replace("/v1", "")
-
-    def _router_client(self):
-        """Return the shared httpx client or an APIError if not connected."""
+    async def _router_request(self, method: str, path: str, json=None, prefix="router request"):
+        """One helper for llama.cpp router calls. Returns parsed json or an APIError."""
+        base = core.config.get("api", "url", default="").rstrip("/").removesuffix("/v1")
+        if not base:
+            return APIError(f"{prefix}: no api.url configured")
         if not self._httpx_client:
-            return APIError("API is not connected. Call connect() first.")
-        return self._httpx_client
+            return APIError(f"{prefix}: API is not connected. Call connect() first.")
+        try:
+            resp = await self._httpx_client.request(method, f"{base}{path}", json=json)
+            if resp.status_code >= 400:
+                return APIError(f"{prefix}: {resp.text}")
+            return resp.json()
+        except Exception as e:
+            return APIError(f"{prefix}", e)
 
     async def load_model(self, model_name: str):
-        """POST /models/load — load a model into VRAM. Success is in the body {'success': True}."""
-        base = self._router_base_url()
-        if not base:
-            return APIError("No api.url configured")
-        client = self._router_client()
-        if isinstance(client, APIError):
-            return client
-        try:
-            resp = await client.post(f"{base}/models/load", json={"model": model_name})
-            if resp.status_code >= 400:
-                return APIError(f"Failed to load {model_name}: {resp.text}")
-            data = resp.json()
-            if not data.get("success"):
-                return APIError(f"Failed to load {model_name}: {data}")
+        """Load a model into VRAM on the llama.cpp router."""
+        data = await self._router_request("POST", "/models/load", json={"model": model_name}, prefix=f"Failed to load {model_name}")
+        if isinstance(data, APIError):
             return data
-        except Exception as e:
-            return APIError(f"Failed to load {model_name}", e)
+        if not data.get("success"):
+            return APIError(f"Failed to load {model_name}: {data}")
+        return data
 
     async def unload_model(self, model_name: str):
-        """POST /models/unload — unload a model from VRAM. Success is in the body {'success': True}."""
-        base = self._router_base_url()
-        if not base:
-            return APIError("No api.url configured")
-        client = self._router_client()
-        if isinstance(client, APIError):
-            return client
-        try:
-            resp = await client.post(f"{base}/models/unload", json={"model": model_name})
-            if resp.status_code >= 400:
-                return APIError(f"Failed to unload {model_name}: {resp.text}")
-            data = resp.json()
-            if not data.get("success"):
-                return APIError(f"Failed to unload {model_name}: {data}")
+        """Unload a model from VRAM on the llama.cpp router."""
+        data = await self._router_request("POST", "/models/unload", json={"model": model_name}, prefix=f"Failed to unload {model_name}")
+        if isinstance(data, APIError):
             return data
-        except Exception as e:
-            return APIError(f"Failed to unload {model_name}", e)
+        if not data.get("success"):
+            return APIError(f"Failed to unload {model_name}: {data}")
+        return data
 
     async def get_loaded_models(self):
-        """GET /models — return list of model IDs currently loaded in VRAM (status == 'loaded')."""
-        base = self._router_base_url()
-        if not base:
-            return APIError("No api.url configured")
-        client = self._router_client()
-        if isinstance(client, APIError):
-            return client
-        try:
-            resp = await client.get(f"{base}/models")
-            if resp.status_code >= 400:
-                return APIError(f"Failed to get loaded models: {resp.text}")
-            data = resp.json()
-            return [m["id"] for m in data.get("data", []) if m.get("status", {}).get("value") == "loaded"]
-        except Exception as e:
-            return APIError("Failed to get loaded models", e)
+        """Models currently loaded in VRAM on the llama.cpp router."""
+        data = await self._router_request("GET", "/models", prefix="Failed to get loaded models")
+        if isinstance(data, APIError):
+            return data
+        return [m["id"] for m in data.get("data", []) if m.get("status", {}).get("value") == "loaded"]
 
     async def list_router_models(self):
-        """GET /models — return ALL discoverable model IDs (loaded, loading, unloaded).
+        """All discoverable model IDs on the router, loaded or not.
 
-        Unlike list_models() (OpenAI /v1/models), which in llama.cpp router mode only reflects
-        the ALREADY LOADED model, this returns the full set a user could switch to.
+        The OpenAI /v1/models endpoint only sees what's already loaded, so this
+        exists for the full list when you want to switch to something new.
         """
-        base = self._router_base_url()
-        if not base:
-            return APIError("No api.url configured")
-        client = self._router_client()
-        if isinstance(client, APIError):
-            return client
-        try:
-            resp = await client.get(f"{base}/models")
-            if resp.status_code >= 400:
-                return APIError(f"Failed to list router models: {resp.text}")
-            data = resp.json()
-            return [m["id"] for m in data.get("data", [])]
-        except Exception as e:
-            return APIError("Failed to list router models", e)
+        data = await self._router_request("GET", "/models", prefix="Failed to list router models")
+        if isinstance(data, APIError):
+            return data
+        return [m["id"] for m in data.get("data", [])]

--- a/core/api.py
+++ b/core/api.py
@@ -739,3 +739,90 @@ class APIClient():
             return []
 
         return model_list
+
+    def _router_base_url(self):
+        """Derive llama.cpp router base URL from api.url config (strip the /v1 suffix)."""
+        url = core.config.get("api", "url", default="")
+        return url.rstrip("/").replace("/v1", "")
+
+    def _router_client(self):
+        """Return the shared httpx client or an APIError if not connected."""
+        if not self._httpx_client:
+            return APIError("API is not connected. Call connect() first.")
+        return self._httpx_client
+
+    async def load_model(self, model_name: str):
+        """POST /models/load — load a model into VRAM. Success is in the body {'success': True}."""
+        base = self._router_base_url()
+        if not base:
+            return APIError("No api.url configured")
+        client = self._router_client()
+        if isinstance(client, APIError):
+            return client
+        try:
+            resp = await client.post(f"{base}/models/load", json={"model": model_name})
+            if resp.status_code >= 400:
+                return APIError(f"Failed to load {model_name}: {resp.text}")
+            data = resp.json()
+            if not data.get("success"):
+                return APIError(f"Failed to load {model_name}: {data}")
+            return data
+        except Exception as e:
+            return APIError(f"Failed to load {model_name}", e)
+
+    async def unload_model(self, model_name: str):
+        """POST /models/unload — unload a model from VRAM. Success is in the body {'success': True}."""
+        base = self._router_base_url()
+        if not base:
+            return APIError("No api.url configured")
+        client = self._router_client()
+        if isinstance(client, APIError):
+            return client
+        try:
+            resp = await client.post(f"{base}/models/unload", json={"model": model_name})
+            if resp.status_code >= 400:
+                return APIError(f"Failed to unload {model_name}: {resp.text}")
+            data = resp.json()
+            if not data.get("success"):
+                return APIError(f"Failed to unload {model_name}: {data}")
+            return data
+        except Exception as e:
+            return APIError(f"Failed to unload {model_name}", e)
+
+    async def get_loaded_models(self):
+        """GET /models — return list of model IDs currently loaded in VRAM (status == 'loaded')."""
+        base = self._router_base_url()
+        if not base:
+            return APIError("No api.url configured")
+        client = self._router_client()
+        if isinstance(client, APIError):
+            return client
+        try:
+            resp = await client.get(f"{base}/models")
+            if resp.status_code >= 400:
+                return APIError(f"Failed to get loaded models: {resp.text}")
+            data = resp.json()
+            return [m["id"] for m in data.get("data", []) if m.get("status", {}).get("value") == "loaded"]
+        except Exception as e:
+            return APIError("Failed to get loaded models", e)
+
+    async def list_router_models(self):
+        """GET /models — return ALL discoverable model IDs (loaded, loading, unloaded).
+
+        Unlike list_models() (OpenAI /v1/models), which in llama.cpp router mode only reflects
+        the ALREADY LOADED model, this returns the full set a user could switch to.
+        """
+        base = self._router_base_url()
+        if not base:
+            return APIError("No api.url configured")
+        client = self._router_client()
+        if isinstance(client, APIError):
+            return client
+        try:
+            resp = await client.get(f"{base}/models")
+            if resp.status_code >= 400:
+                return APIError(f"Failed to list router models: {resp.text}")
+            data = resp.json()
+            return [m["id"] for m in data.get("data", [])]
+        except Exception as e:
+            return APIError("Failed to list router models", e)

--- a/modules/models.py
+++ b/modules/models.py
@@ -1,21 +1,42 @@
+import asyncio
+
 import core
 
+
 class Models(core.module.Module):
-    """Lets you or the AI switch between AI models"""
+    """Lets you or the AI switch between AI models.
+
+    By default switching is a config-only change (the base models module assumes the
+    target model is already loaded in VRAM). When ``enable_model_load_unload`` is on,
+    switching actively unloads the running model and loads the target through the
+    llama.cpp router HTTP API (``/models/load``, ``/models/unload``, ``/models``).
+    The server URL is derived from ``api.url`` (the ``/v1`` suffix is stripped).
+    """
 
     settings = {
         "insert_current_model_into_system_prompt": {
-            "description" :"Whether to make the AI aware of what model it's currently running on. Can help it stay grounded!",
+            "description": "Whether to make the AI aware of what model it's currently running on. Can help it stay grounded!",
             "default": True
         },
         "insert_available_models_into_system_prompt": {
             "description": "Whether to make the AI aware of what models are available for it to switch to. Allows you to simply ask the AI to switch to whatever model you want (example: `switch to Qwen3.5-9B`) and it'll just do it ",
             "default": False
-        }
+        },
+        "enable_model_load_unload": {
+            "type": "boolean",
+            "description": "Enable dynamic model loading/unloading via the llama.cpp router. When disabled, /model only changes config.",
+            "default": False
+        },
+        "unload_wait_seconds": {
+            "type": "number",
+            "description": "Seconds to wait between unloading the old model and loading the new one. Needed for VRAM to clear.",
+            "default": 10
+        },
     }
 
     async def on_ready(self):
         self.models = None
+        self._switch_lock = asyncio.Lock()
 
         if self.config.get("insert_available_models_into_system_prompt"):
             self.disabled_tools.append("get_available")
@@ -23,34 +44,40 @@ class Models(core.module.Module):
     async def on_system_prompt(self):
         output = ""
 
+        current_model = self.manager.API.get_model()
+
         if self.config.get("insert_current_model_into_system_prompt"):
-            current_model = self.manager.API.get_model()
             output += f"Current model: {current_model}"
 
-        current_model = self.manager.API.get_model()
-        
-        if self.config.get("insert_available_models_into_system_prompt"):
-            if not self.models:
-                models = await self.manager.API.list_models()
-                if not models:
-                    return output if output else None
-                self.models = models
+        if self.config.get("enable_model_load_unload"):
+            loaded = await self.manager.API.get_loaded_models()
+            if isinstance(loaded, core.api.APIError):
+                output += f"\n\n(Unable to query loaded models: {loaded})"
+            elif loaded:
+                output += f"\nCurrently loaded (in VRAM): {', '.join(loaded)}"
 
-            if len(self.models) > 1:
+        if self.config.get("insert_available_models_into_system_prompt"):
+            await self._load_models()
+            if self.models and len(self.models) > 1:
                 output += f"\n\nModels you can switch to using the models_switch() toolcall: "
                 output += ", ".join(self.models)
-        else:
-            self.header = "current model"
-            output = current_model
 
         return output
 
     async def _load_models(self):
-        if not self.models:
+        if self.models:
+            return
+
+        if self.config.get("enable_model_load_unload"):
+            models = await self.manager.API.list_router_models()
+        else:
             models = await self.manager.API.list_models()
-            if not models:
-                return None
-            self.models = models
+
+        if not models:
+            return None
+        if isinstance(models, core.api.APIError):
+            return None
+        self.models = models
 
     async def get_available(self):
         """Returns a list of AI/LLM models available to switch to"""
@@ -78,15 +105,37 @@ class Models(core.module.Module):
     async def models(self, args: list):
         """Lists available models."""
         await self._load_models()
+        if not self.models:
+            return "Unable to fetch model list."
         return "\n".join(self.models)+"\n\nUse `/model <name>` to switch to your model of choice"
+
+    @core.module.command("model_status")
+    async def model_status(self, args: list):
+        """Shows currently loaded model(s) and available models."""
+        output = []
+        current = self.manager.API.get_model()
+        output.append(f"Current model (config): {current}")
+
+        if self.config.get("enable_model_load_unload"):
+            loaded = await self.manager.API.get_loaded_models()
+            if isinstance(loaded, core.api.APIError):
+                output.append(f"Currently loaded: unavailable ({loaded})")
+            elif loaded:
+                output.append(f"Currently loaded (in VRAM): {', '.join(loaded)}")
+            else:
+                output.append("Currently loaded: none")
+
+        await self._load_models()
+        if self.models:
+            output.append(f"Available models: {', '.join(self.models)}")
+        return "\n".join(output)
 
     async def switch(self, name: str):
         """Switches you to a different AI model"""
+        await self._load_models()
+
         if not self.models:
-            models = await self.manager.API.list_models()
-            if not models:
-                return None
-            self.models = models
+            return None
 
         found = False
         found_id = None
@@ -98,6 +147,12 @@ class Models(core.module.Module):
         if not found:
             return "model does not exist. use models_get_available() first"
 
+        if self.config.get("enable_model_load_unload"):
+            result = await self._switch_with_load_unload(found_id)
+            if isinstance(result, str):
+                return result
+            return f"model has been switched to {found_id}"
+
         core.config.config["model"]["name"] = found_id
         core.config.config.save()
 
@@ -105,3 +160,54 @@ class Models(core.module.Module):
 
         return f"model has been switched to {found_id}"
 
+    async def _switch_with_load_unload(self, found_id: str):
+        """Unload the running model, wait for VRAM, then load the target."""
+        async with self._switch_lock:
+            loaded = await self.manager.API.get_loaded_models()
+            if isinstance(loaded, core.api.APIError):
+                # graceful degradation: fall back to config-only switch with a warning
+                self.channel.log(self.name, f"Load/unload unavailable, falling back to config-only switch: {loaded}")
+                self._config_only_switch(found_id)
+                return None
+
+            loaded_id = None
+            for m in loaded:
+                if m.strip().lower() == found_id.strip().lower():
+                    loaded_id = m
+                    break
+
+            if loaded_id:
+                # fast path: target is already loaded
+                self._config_only_switch(found_id)
+                return None
+
+            # unload whatever is currently loaded
+            for m in loaded:
+                self.channel.log(self.name, f"Unloading current model: {m}")
+                unload = await self.manager.API.unload_model(m)
+                if isinstance(unload, core.api.APIError):
+                    self.channel.log(self.name, f"Failed to unload {m}: {unload}")
+                    continue
+                break
+
+            wait = self.config.get("unload_wait_seconds", default=10) or 10
+            if wait > 0:
+                self.channel.log(self.name, f"Waiting {wait} seconds for VRAM to clear...")
+                await asyncio.sleep(wait)
+
+            self.channel.log(self.name, f"Loading model: {found_id}")
+            load = await self.manager.API.load_model(found_id)
+            if isinstance(load, core.api.APIError):
+                # graceful fallback: keep config consistent but warn user
+                self.channel.log(self.name, f"Failed to load {found_id}: {load}. Config updated but VRAM state unknown.")
+                self._config_only_switch(found_id)
+                return None
+
+            self._config_only_switch(found_id)
+            self.channel.log(self.name, f"Successfully loaded {found_id}")
+            return None
+
+    def _config_only_switch(self, found_id: str):
+        core.config.config["model"]["name"] = found_id
+        core.config.config.save()
+        self.manager.API.set_model(found_id)

--- a/modules/models.py
+++ b/modules/models.py
@@ -160,6 +160,26 @@ class Models(core.module.Module):
 
         return f"model has been switched to {found_id}"
 
+    async def apply_config_model(self):
+        """Ensure the model configured in core config (model.name) is the one loaded in VRAM.
+
+        Called by the web UI after a settings save. Only acts when
+        ``enable_model_load_unload`` is on; otherwise this is a no-op.
+        """
+        if not self.config.get("enable_model_load_unload"):
+            return None
+
+        target = core.config.get("model", "name")
+        if not target:
+            return None
+
+        await self._load_models()
+        if not self.models:
+            return None
+
+        await self._switch_with_load_unload(target)
+        return None
+
     async def _switch_with_load_unload(self, found_id: str):
         """Unload the running model, wait for VRAM, then load the target."""
         async with self._switch_lock:

--- a/modules/models.py
+++ b/modules/models.py
@@ -6,11 +6,9 @@ import core
 class Models(core.module.Module):
     """Lets you or the AI switch between AI models.
 
-    By default switching is a config-only change (the base models module assumes the
-    target model is already loaded in VRAM). When ``enable_model_load_unload`` is on,
-    switching actively unloads the running model and loads the target through the
-    llama.cpp router HTTP API (``/models/load``, ``/models/unload``, ``/models``).
-    The server URL is derived from ``api.url`` (the ``/v1`` suffix is stripped).
+    By default that's just a config change. With enable_model_load_unload on it
+    unloads the previously selected model and loads the target through the llama.cpp
+    router instead, so switching works on a VRAM-constrained box.
     """
 
     settings = {
@@ -148,7 +146,7 @@ class Models(core.module.Module):
             return "model does not exist. use models_get_available() first"
 
         if self.config.get("enable_model_load_unload"):
-            result = await self._switch_with_load_unload(found_id)
+            result = await self._switch_with_load_unload(found_id, self.manager.API.get_model())
             if isinstance(result, str):
                 return result
             return f"model has been switched to {found_id}"
@@ -160,11 +158,12 @@ class Models(core.module.Module):
 
         return f"model has been switched to {found_id}"
 
-    async def apply_config_model(self):
-        """Ensure the model configured in core config (model.name) is the one loaded in VRAM.
+    async def apply_config_model(self, previous: str = None):
+        """Make sure the model in core config is the one loaded in VRAM.
 
-        Called by the web UI after a settings save. Only acts when
-        ``enable_model_load_unload`` is on; otherwise this is a no-op.
+        Called by the web UI after a settings save. previous is the model that
+        was active before the change; only unload that one. No-op unless
+        enable_model_load_unload is on.
         """
         if not self.config.get("enable_model_load_unload"):
             return None
@@ -177,54 +176,52 @@ class Models(core.module.Module):
         if not self.models:
             return None
 
-        await self._switch_with_load_unload(target)
+        await self._switch_with_load_unload(target, previous)
         return None
 
-    async def _switch_with_load_unload(self, found_id: str):
-        """Unload the running model, wait for VRAM, then load the target."""
+    async def _switch_with_load_unload(self, found_id: str, previous: str = None):
+        """Unload the previously selected model, wait for VRAM, then load the target."""
+        if not previous:
+            previous = self.manager.API.get_model()
+
         async with self._switch_lock:
             loaded = await self.manager.API.get_loaded_models()
             if isinstance(loaded, core.api.APIError):
-                # graceful degradation: fall back to config-only switch with a warning
-                self.channel.log(self.name, f"Load/unload unavailable, falling back to config-only switch: {loaded}")
+                self.log(self.name, f"Load/unload unavailable, falling back to config-only switch: {loaded}")
+                self._config_only_switch(found_id)
+                return f"switched to {found_id} in config only (couldn't reach the router): {loaded}"
+
+            # fast path: the target is already the one sitting in VRAM
+            if any(m.strip().lower() == found_id.strip().lower() for m in loaded):
                 self._config_only_switch(found_id)
                 return None
 
-            loaded_id = None
-            for m in loaded:
-                if m.strip().lower() == found_id.strip().lower():
-                    loaded_id = m
-                    break
+            unloaded = False
+            if previous:
+                for m in loaded:
+                    if m.strip().lower() == previous.strip().lower():
+                        self.log(self.name, f"Unloading previous model: {m}")
+                        unload = await self.manager.API.unload_model(m)
+                        if isinstance(unload, core.api.APIError):
+                            self.log(self.name, f"Failed to unload {m}: {unload}")
+                        else:
+                            unloaded = True
+                        break
 
-            if loaded_id:
-                # fast path: target is already loaded
-                self._config_only_switch(found_id)
-                return None
+            if unloaded:
+                wait = self.config.get("unload_wait_seconds") or 10
+                if wait > 0:
+                    self.log(self.name, f"Waiting {wait} seconds for VRAM to clear...")
+                    await asyncio.sleep(wait)
 
-            # unload whatever is currently loaded
-            for m in loaded:
-                self.channel.log(self.name, f"Unloading current model: {m}")
-                unload = await self.manager.API.unload_model(m)
-                if isinstance(unload, core.api.APIError):
-                    self.channel.log(self.name, f"Failed to unload {m}: {unload}")
-                    continue
-                break
-
-            wait = self.config.get("unload_wait_seconds", default=10) or 10
-            if wait > 0:
-                self.channel.log(self.name, f"Waiting {wait} seconds for VRAM to clear...")
-                await asyncio.sleep(wait)
-
-            self.channel.log(self.name, f"Loading model: {found_id}")
+            self.log(self.name, f"Loading model: {found_id}")
             load = await self.manager.API.load_model(found_id)
             if isinstance(load, core.api.APIError):
-                # graceful fallback: keep config consistent but warn user
-                self.channel.log(self.name, f"Failed to load {found_id}: {load}. Config updated but VRAM state unknown.")
+                self.log(self.name, f"Failed to load {found_id}: {load}. Config updated, VRAM state unknown.")
                 self._config_only_switch(found_id)
-                return None
+                return f"switched to {found_id} in config only, load failed: {load}"
 
             self._config_only_switch(found_id)
-            self.channel.log(self.name, f"Successfully loaded {found_id}")
             return None
 
     def _config_only_switch(self, found_id: str):


### PR DESCRIPTION
I took a look through my PR and the project this afternoon and I thought it best to be honest. I generated the PR with AI assistance for a problem I was having on my resource constrained local server. This is my best attempt to improve it, but if this would be better as a feature request and not a PR, please let me know! Change description below:

This change turns my `model_switcher` user module into built-in behaviour for the `models` module. On a VRAM-constrained box, switching models now actually unloads the running model and loads the new one through the llama.cpp router API, instead of just flipping a config value.

What changed:

- `core/api.py` — small wrappers for the router (`/models/load`, `/models/unload`, the loaded list). The router URL is derived from your existing `api.url`, so there's still no second URL to configure.
- `modules/models.py` — new `enable_model_load_unload` setting (default off, so nothing changes unless you turn it on). When on, `/model` unloads the previously selected model, waits a few seconds for VRAM (`unload_wait_seconds`), loads the target, then updates the config. Adds a `/model_status` command that shows what's actually in VRAM vs what the config thinks is active, and surfaces the same info in the system prompt. If the router is unreachable it falls back to the old config-only switch instead of erroring out.
- `channels/webui.py` — saving a different model in the settings panel triggers the same unload/load when the feature is enabled.

Tested against a local llama.cpp router: Qwen-27B only fits in VRAM if the previous model is unloaded first — that's exactly the case this solves. Nothing changes with the feature off (the default).

Known gaps:
I have only tested this locally with llama.cpp. This change likely will not work on other inference backends like vLLM.