### PR TITLE
Fix: added if blocks in _censor_ip def to catch IPv4/IPv6 addresses 

### DIFF
--- a/modules/http.py
+++ b/modules/http.py
@@ -947,9 +947,10 @@ class Http(core.module.Module):
         """Replaces IPv4 and IPv6 addresses with [CENSORED_IP]."""
         if not isinstance(text, str):
             return text
-
-        text = text.replace(self.server_ipv4, "[CENSORED_IP]")
-        text = text.replace(self.server_ipv6, "[CENSORED_IP]")
+        if self.server_ipv4 is not None:
+            text = text.replace(self.server_ipv4, "[CENSORED_IP]")
+        if self.server_ipv6 is not None:
+            text = text.replace(self.server_ipv6, "[CENSORED_IP]")
         return text
 
     # ==================== SSRF Protection ====================


### PR DESCRIPTION
Fixes #71

Updates http.py to wrap the IP replacement lines in _censor_ip in if blocks to catch when the fetched IPv4/IPv6 addresses are set to None, which happens when there is an exception fetching them.