### PR TITLE
webui: edit box UX improvements

### DIFF
--- a/channels/webui.py
+++ b/channels/webui.py
@@ -920,7 +920,7 @@ async def create_fastapi(channel):
                                 await channel.context.chat.messages.delete_from(max(0, last_user_message_index))
 
                                 await ws_mgr.broadcast({"type": "sync"})
-                                await ws_mgr.start_stream(channel, channel.context.chat.get("id"), user_message.get("content"))
+                                await ws_mgr.start_stream(channel, channel.context.chat.get("id"), user_message)
                         case _:
                             channel.log(channel.name, f"Unknown websocket command received: {msg_type}")
 

--- a/channels/webui.py
+++ b/channels/webui.py
@@ -886,6 +886,11 @@ async def create_fastapi(channel):
 
                             message = await channel.context.chat.messages.get(index)
                             message["content"] = data.get("content")
+
+                            filenames = data.get("filenames")
+                            if filenames is not None:
+                                message.setdefault("_metadata", {})["filenames"] = filenames
+
                             await channel.context.chat.messages.edit(index, message)
 
                             await ws_mgr.broadcast({

--- a/channels/webui/assets/css/chat/message_bubble.css
+++ b/channels/webui/assets/css/chat/message_bubble.css
@@ -184,6 +184,9 @@
                 textarea {
                     width: 100%;
                     min-height: 60px;
+                    max-height: 80vh;
+                    /* autosize switches to scroll when the content hits max-height */
+                    overflow-y: hidden;
                     padding: 8px;
                     background: var(--bg-input);
                     color: var(--text-primary);

--- a/channels/webui/assets/css/chat/message_bubble.css
+++ b/channels/webui/assets/css/chat/message_bubble.css
@@ -240,6 +240,62 @@
                         }
                     }
                 }
+
+                .edit-files {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 4px;
+                    padding: 8px;
+                    background: var(--bg-tertiary);
+                    border: 1px solid var(--border-color);
+                    border-radius: var(--radius-sm);
+                    max-width: 100%;
+
+                    .edit-file-row {
+                        display: flex;
+                        align-items: center;
+                        gap: 8px;
+
+                        .edit-file-remove {
+                            width: 28px;
+                            height: 28px;
+                            padding: 0;
+                            flex-shrink: 0;
+                            background: var(--bg-tertiary);
+                            border: 1px solid var(--border-color);
+                            border-radius: var(--radius-md);
+                            color: var(--text-secondary);
+                            cursor: pointer;
+                            display: flex;
+                            align-items: center;
+                            justify-content: center;
+                            opacity: 0.6;
+                            transition: all 0.2s ease;
+
+                            svg {
+                                width: 14px;
+                                height: 14px;
+                            }
+
+                            &:hover {
+                                background: var(--bg-secondary);
+                                color: var(--error);
+                                border-color: var(--error);
+                                opacity: 1;
+                            }
+
+                            &:active {
+                                transform: scale(0.95);
+                            }
+                        }
+
+                        .edit-file-name {
+                            font-size: 0.85rem;
+                            color: var(--text-secondary);
+                            word-break: break-all;
+                        }
+                    }
+                }
             }
         }
 

--- a/channels/webui/assets/css/chat/message_bubble.css
+++ b/channels/webui/assets/css/chat/message_bubble.css
@@ -15,6 +15,13 @@
         position: relative;
         max-width: var(--message-max-width, 75%);
         width: fit-content;
+
+        /* when a message is being edited, expand the bubble to its max width
+           so the edit box doesn't collapse to the textarea's intrinsic size */
+        &.editing-active {
+            width: 100%;
+        }
+
         backdrop-filter: blur(10px);
 
         .command {

--- a/channels/webui/assets/js/stores/chat.js
+++ b/channels/webui/assets/js/stores/chat.js
@@ -16,6 +16,7 @@ CHAT_STORE = {
     turnHistory: [],
     editingMessageIndex: null,
     editContent: '',
+    editAttached: [],
 
     user_input: '',
     last_user_input: '',
@@ -273,6 +274,9 @@ CHAT_STORE = {
         
         this.editingMessageIndex = msg.index;
         this.editContent = this._extractEditText(msg);
+        // files currently attached (excluding the '' text slot) - the working set
+        // for this edit session; changes only commit on save
+        this.editAttached = (msg._metadata?.filenames || []).filter(f => f);
         Alpine.store('ui').scrollToTurnIndex = turnIndex;
 
         // after Alpine renders the edit box, scroll its top into view
@@ -307,45 +311,69 @@ CHAT_STORE = {
     async cancelEdit() {
         this.editingMessageIndex = null;
         this.editContent = '';
+        this.editAttached = [];
+    },
+
+    removeEditFile(fname) {
+        this.editAttached = this.editAttached.filter(f => f !== fname);
+    },
+
+    _findMessage(index) {
+        for (const turn of this.turnHistory) {
+            const found = (turn.messages || []).find(m => m.index === index);
+            if (found) { return found; }
+        }
+        return null;
     },
 
     async saveEdit(index) {
         // find the original message so we can preserve any attached files
-        let origMessage = null;
-        for (const turn of this.turnHistory) {
-            const found = (turn.messages || []).find(m => m.index === index);
-            if (found) { origMessage = found; break; }
-        }
+        let origMessage = this._findMessage(index);
 
         let content = this.editContent;
+        let filenames = null;
 
         if (origMessage && Array.isArray(origMessage.content)) {
-            // keep the file blocks, only replace the first text block (the actual message)
+            // keep the file blocks, only replace the first text block (the actual message),
+            // and drop any blocks whose file is no longer in the edit working set
+            const attached = this.editAttached;
             let replacedText = false;
-            const blocks = origMessage.content.map(block => {
+            const blocks = [];
+            const names = [];
+
+            origMessage.content.forEach((block, blockIndex) => {
+                const fname = origMessage._metadata?.filenames?.[blockIndex];
+                if (fname && !attached.includes(fname)) { return; } // file removed by user
+
                 if (block.type === 'text' && !replacedText) {
                     replacedText = true;
-                    return { ...block, text: content };
+                    blocks.push({ ...block, text: content });
+                } else {
+                    blocks.push(block);
                 }
-                return block;
+                names.push(fname || '');
             });
 
             // if the message had no text block but the user typed something, add one
             if (!replacedText && content) {
                 blocks.unshift({ type: 'text', text: content });
+                names.unshift('');
             }
 
             content = blocks;
+            filenames = names;
         }
 
         await simpleSocketSend({
             "type": "message_edit",
             "index": index,
-            "content": content
+            "content": content,
+            "filenames": filenames
         });
 
         this.editingMessageIndex = null;
         this.editContent = '';
+        this.editAttached = [];
     },
 
     /* ----------------------

--- a/channels/webui/assets/js/stores/chat.js
+++ b/channels/webui/assets/js/stores/chat.js
@@ -268,6 +268,14 @@ CHAT_STORE = {
         this.editingMessageIndex = msg.index;
         this.editContent = this._extractEditText(msg);
         Alpine.store('ui').scrollToTurnIndex = turnIndex;
+
+        // after Alpine renders the edit box, scroll its top into view
+        // (the bubble collapses when entering edit mode, which can leave
+        //  the edit box above the visible area)
+        Alpine.nextTick(() => {
+            const turnEl = document.querySelector(`[data-turn-index="${turnIndex}"]`);
+            turnEl?.querySelector('.editing textarea')?.scrollIntoView({ block: 'start' });
+        });
     },
 
     /*

--- a/channels/webui/assets/js/stores/chat.js
+++ b/channels/webui/assets/js/stores/chat.js
@@ -227,7 +227,13 @@ CHAT_STORE = {
       const turn = this.turnHistory[turnIndex];
       const msg = turn?.messages?.[turn.messages?.length - 1]; // last message in the turn
       if (!msg) return;
-      navigator.clipboard.writeText(msg.content)
+
+      // copy and edit should always show the same content (text).
+      const text = Array.isArray(msg.content)
+          ? this._extractEditText(msg)
+          : msg.content;
+
+      navigator.clipboard.writeText(text)
         .then(() => {
             return true;
         })

--- a/channels/webui/assets/js/stores/chat.js
+++ b/channels/webui/assets/js/stores/chat.js
@@ -266,8 +266,28 @@ CHAT_STORE = {
         if (!msg) { return; }
         
         this.editingMessageIndex = msg.index;
-        this.editContent = msg.content;
+        this.editContent = this._extractEditText(msg);
         Alpine.store('ui').scrollToTurnIndex = turnIndex;
+    },
+
+    /*
+     * messages with attached files store their content as an array of blocks
+     * (text + image_url/input_audio/text blocks for files).
+     * only the first block is the user's own editable text
+     * (it is the only one with an empty entry in _metadata.filenames).
+     */
+    _extractEditText(msg) {
+        if (Array.isArray(msg.content)) {
+            const filenames = msg._metadata?.filenames;
+            const isUserTextFirst = Array.isArray(filenames) && filenames[0] === '';
+            if (isUserTextFirst) {
+                const textBlock = msg.content.find(block => block.type === 'text');
+                return textBlock?.text ?? '';
+            }
+            // no user text (pure file upload) - nothing editable
+            return '';
+        }
+        return msg.content;
     },
 
     async cancelEdit() {
@@ -276,10 +296,38 @@ CHAT_STORE = {
     },
 
     async saveEdit(index) {
+        // find the original message so we can preserve any attached files
+        let origMessage = null;
+        for (const turn of this.turnHistory) {
+            const found = (turn.messages || []).find(m => m.index === index);
+            if (found) { origMessage = found; break; }
+        }
+
+        let content = this.editContent;
+
+        if (origMessage && Array.isArray(origMessage.content)) {
+            // keep the file blocks, only replace the first text block (the actual message)
+            let replacedText = false;
+            const blocks = origMessage.content.map(block => {
+                if (block.type === 'text' && !replacedText) {
+                    replacedText = true;
+                    return { ...block, text: content };
+                }
+                return block;
+            });
+
+            // if the message had no text block but the user typed something, add one
+            if (!replacedText && content) {
+                blocks.unshift({ type: 'text', text: content });
+            }
+
+            content = blocks;
+        }
+
         await simpleSocketSend({
             "type": "message_edit",
             "index": index,
-            "content": this.editContent
+            "content": content
         });
 
         this.editingMessageIndex = null;

--- a/channels/webui/templates/chat/index.html
+++ b/channels/webui/templates/chat/index.html
@@ -42,7 +42,7 @@
             <!-- user turn (always one message) -->
             <template x-if="turn.role === 'user'">
                 <div class="message-wrapper user" x-data="{ get message() { return turn.messages[0] } }">
-                    <div class="message user">
+                    <div class="message user" :class="{'editing-active': $store.chat.editingMessageIndex === turn.first_message_index}">
                         {% include 'chat/turns/user.html' %}
                         <div x-data="{ get targetIndex() { return turn.first_message_index } }" class="fullwidth">
                             {% include 'chat/message_buttons.html' %}
@@ -54,7 +54,7 @@
             <!-- assistant turn (multiple messages combined into one bubble) -->
             <template x-if="turn.role === 'assistant'">
                 <div class="message-wrapper assistant">
-                    <div class="message assistant">
+                    <div class="message assistant" :class="{'editing-active': $store.chat.editingMessageIndex === turn.last_message_index}">
                         <template x-for="(message, messageIndex) in turn.messages" :key="messageIndex">
                             {% include 'chat/turns/assistant_history.html' %}
                         </template>

--- a/channels/webui/templates/chat/turns/assistant_history.html
+++ b/channels/webui/templates/chat/turns/assistant_history.html
@@ -14,7 +14,7 @@
             </template>
             <template x-if="$store.chat.editingMessageIndex === turn.last_message_index">
                 <div class="flex fullwidth editing">
-                    <textarea x-model="$store.chat.editContent" rows="3"></textarea>
+                    <textarea x-model="$store.chat.editContent" rows="3" x-autosize @focus="$autosize($el)"></textarea>
                     <div class="edit-actions">
                         <button @click="$store.chat.saveEdit($store.chat.editingMessageIndex)">Save</button>
                         <button @click="$store.chat.cancelEdit()">Cancel</button>

--- a/channels/webui/templates/chat/turns/user.html
+++ b/channels/webui/templates/chat/turns/user.html
@@ -33,7 +33,7 @@
 
 <template x-if="$store.chat.editingMessageIndex === turn.first_message_index">
     <div class="flex fullwidth editing">
-        <textarea x-model="$store.chat.editContent" rows="3"></textarea>
+        <textarea x-model="$store.chat.editContent" rows="3" x-autosize @focus="$autosize($el)"></textarea>
         <div class="edit-actions">
             <button @click="$store.chat.saveEdit($store.chat.editingMessageIndex)">Save</button>
             <button @click="$store.chat.cancelEdit()">Cancel</button>

--- a/channels/webui/templates/chat/turns/user.html
+++ b/channels/webui/templates/chat/turns/user.html
@@ -38,5 +38,17 @@
             <button @click="$store.chat.saveEdit($store.chat.editingMessageIndex)">Save</button>
             <button @click="$store.chat.cancelEdit()">Cancel</button>
         </div>
+        <template x-if="$store.chat.editAttached.length > 0">
+            <div class="edit-files">
+                <template x-for="fname in $store.chat.editAttached" :key="fname">
+                    <div class="edit-file-row">
+                        <button class="edit-file-remove" title="Remove file" @click="$store.chat.removeEditFile(fname)">
+                            {% include 'svg/cross.svg' %}
+                        </button>
+                        <span class="edit-file-name" x-text="fname"></span>
+                    </div>
+                </template>
+            </div>
+        </template>
     </div>
 </template>

--- a/core/channel.py
+++ b/core/channel.py
@@ -232,7 +232,7 @@ class Channel:
     # ---------------------
     # Content Processors
     # ---------------------
-    async def _process_multimodal(self, message: str = None, files: list = None) -> list:
+    async def _process_multimodal(self, message: str = None, files: list = None, metadata: dict = None) -> list:
         """
         Converts a list of file handler objects into an openAI API multimodal message object,
         allowing the AI to process images, audio, etc.
@@ -245,12 +245,18 @@ class Channel:
             "my_audio.mp3": (file handler object),
             and so on
         }
+
+        `metadata` is preserved when the message is already multimodal.
         """
         content_blocks = []
 
         # if the message was a list... this was already multimodal, so dont modify
         if isinstance(message, list):
-            return {"role": "user", "content": message}
+            result = {"role": "user", "content": message}
+            if metadata:
+                # copy so we don't mutate the caller's dict
+                result["_metadata"] = dict(metadata)
+            return result
 
         if not message and not files:
             # wtf why would you do that
@@ -418,15 +424,21 @@ class Channel:
         """
         internal helper function so that send() and send_stream()
         both use many of the same code paths and i don't have to keep maintaining each one individually
+
+        if the message is a dict (e.g. regenerate passes the stored message through),
+        its `_metadata` is preserved so attachment info like `_metadata.filenames`
+        survives being re-added to history.
         """
         await self._set_as_active_channel()
         user_message = message
+        metadata = None
 
         # sometimes legacy parts of the openlumara framework still send dicts.
         # that is not supposed to happen, and i need to find the code that does it
         # so, TODO: find the legacy code that calls channel.send()/send_stream() with dicts
         # but for now.. to avoid breaking everything, i'll convert
         if isinstance(user_message, dict):
+            metadata = user_message.get("_metadata")
             user_message = user_message.get("content", "")
 
         if isinstance(user_message, str):
@@ -467,7 +479,7 @@ class Channel:
                         user_message = usr_msg_result
 
         # apply multimodal content if applicable
-        user_message_processed = await self._process_multimodal(message=user_message, files=files)
+        user_message_processed = await self._process_multimodal(message=user_message, files=files, metadata=metadata)
 
         # and add the user's message to context
         add_success = await self.context.chat.messages.add(user_message_processed)


### PR DESCRIPTION
Warning: the code changes were generated with an LLM (breaking the AI Usage Policy of this project). I am making this clear so I don't get banned. As the AI would say, "the improvements are real", at least for me, but not up to the standards of this project. I hope they can inspire real human changes to improve my experience with OpenLumara.

This PR has three main parts:
1. Adds some improvements to the text-box used for editing (to not be a small minuscule text-box) by making it take the full width of the text bubble and expand the height to fit the text or a max 80% of the viewport height. I also repositions the view to the text box (as it would scroll away and I would have to scroll up to edit the text). The experience is much better for me when editing large blocks of text.
2. Fix an issue where, if a user reply contains an attachment, and I want to edit the message, I would get `[object Object],[object Object]` instead of the message. Now this is fixed (and I can edit the text) while preserving the attachment.
3. Manage attached files in Edit mode (can only remove files for now). I think a refactoring is needed to make it possible to add files in a more general way that works for both first message send and edit mode.

Note: if this kind of PR is not welcome, let me know (say explicitly) so I don't repeat the same mistake.