### PR TITLE
Save Settings Fix

### DIFF
--- a/channels/webui.py
+++ b/channels/webui.py
@@ -610,7 +610,7 @@ async def create_fastapi(channel):
                 try:
                     await channel.manager.reload_module(module_name)
                 except Exception as e:
-                    channel.log(self.name, f"Error reloading module {module_name}: {core.detail_error(e)}")
+                    channel.log(channel.name, f"Error reloading module {module_name}: {core.detail_error(e)}")
 
         return api_result(success=True)
     


### PR DESCRIPTION
Messing around with a local fork, I discovered this bug in the settings save function. A 'NameError: name 'self' is not defined' is raised inside the FastAPI route in channels/webui.py. The crash occurs after core.config.config.save() but before the module reload loop, so every settings save writes the client's full config snapshot to disk and then dies before reloading any modules whose settings changed.

AI attestation: I found this bug with the help of AI but it was confirmed and fixed by hand.