### PR TITLE
fix(webui): undefined `files` drops file-only messages; `self.name` in settings_save

### DIFF
--- a/channels/webui.py
+++ b/channels/webui.py
@@ -610,7 +610,7 @@ async def create_fastapi(channel):
                 try:
                     await channel.manager.reload_module(module_name)
                 except Exception as e:
-                    channel.log(self.name, f"Error reloading module {module_name}: {core.detail_error(e)}")
+                    channel.log(channel.name, f"Error reloading module {module_name}: {core.detail_error(e)}")
 
         return api_result(success=True)
     
@@ -867,7 +867,7 @@ async def create_fastapi(channel):
                             text = data.get("content")
                             files_data = data.get("files")
 
-                            if not text and not files:
+                            if not text and not files_data:
                                 break
 
                             files_dict = None


### PR DESCRIPTION
Two `NameError`s in `channels/webui.py`, both found with `pyflakes`.

## 1. `files` vs `files_data` — file-only messages are silently dropped

```python
# channels/webui.py:866-871, websocket_endpoint()
case "user_message":
    text = data.get("content")
    files_data = data.get("files")

    if not text and not files:      # <-- `files` is never bound in this scope
        break
```

`files` is not defined anywhere in `websocket_endpoint` (776-936) nor at module level — the other `files` in this file are locals of `get_recursive_assets()` and of the `os.walk` loops. The two lines below already use the correct name (`if files_data:`).

`and` short-circuits, so `files` is only evaluated when `text` is falsy: a message carrying attachments but **no caption**. That raises `NameError`, which is caught by

```python
# channels/webui.py:930
except Exception as e:
    channel.log(channel.name, f"WebSocket command error: {core.detail_error(e)}")
```

so the message is dropped without any user-visible feedback.

Verified by executing the verbatim source slice:

```
[UNPATCHED] NameError: name 'files' is not defined
[PATCHED]   guard passed -> message forwarded
```

with `data = {"content": "", "files": [{"name": "a.png", "data": "aGk="}]}`.

## 2. `self.name` in `settings_save()`

```python
# channels/webui.py:610-613
try:
    await channel.manager.reload_module(module_name)
except Exception as e:
    channel.log(self.name, f"Error reloading module {module_name}: {core.detail_error(e)}")
```

`settings_save` is a module-level route function — there is no `self`. Every other call site in this file uses `channel.name`:

```
669:  channel.log(channel.name, f"failed to read theme {filepath}: {e}")
688:  channel.log(channel.name, f"failed to load theme {filepath}: {e}")
925:  channel.log(channel.name, f"Unknown websocket command received: {msg_type}")
930:  channel.log(channel.name, f"WebSocket command error: ...")
935:  channel.log(channel.name, f"WebSocket error: ...")
1062: channel.log(channel.name, f"Background stream error: ...")
```

As written, a module that fails to reload turns the intended log line into a `NameError` that escapes the handler and 500s `POST /api/settings/save` — the settings are already saved at that point, so the UI reports a failure for a save that succeeded.

## Fix

`files` → `files_data`, `self.name` → `channel.name`. Two words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
