### PR TITLE
context: add a toggle to preserve multimotal content

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -112,6 +112,10 @@ core_settings_schema = {
             },
             "depends": "enable_thinking"
         },
+        "preserve_multimodal_context": {
+            "default": False,
+            "description": "Whether to keep multimodal content (images, audio) in the chat history. Disabling this saves a significant amount of tokens by stripping multimedia from all but the last message."
+        },
     },
     "channels": {
         "enabled": {

--- a/core/context.py
+++ b/core/context.py
@@ -97,7 +97,8 @@ class Context:
                 messages = messages[-max_messages:]
 
             # Strip multimodal data from all messages except the last one to save tokens
-            if messages:
+            # ONLY if the preserve_multimodal_context setting is disabled
+            if messages and not core.config.get("model", "preserve_multimodal_context"):
                 for i in range(len(messages) - 1):
                     msg = messages[i]
                     if msg.get("role") in ("tool", "tool_calls"):


### PR DESCRIPTION
I have observed that, when adding an image, after the first tool call the model forgets what the image is. If the description of the image is not in the thinking tokens, then it cannot "see" the image and the other operations don't work. I have added a toggle in settings/model to let the user decide if they want to preserve the multimodal context or not (off by default, as it use to be).

If nobody else had this issue before, and they cannot reproduce, then maybe this is on my end.

Thanks for reading.